### PR TITLE
 fix: update deprecated Module.* APIs for Frida v17

### DIFF
--- a/ios/ios-connect-hook.js
+++ b/ios/ios-connect-hook.js
@@ -20,12 +20,13 @@
 
 // This is the method we're going to patch:
 // https://developer.apple.com/documentation/network/2976677-nw_connection_create (iOS 12+)
-const nw_connection_create = Module.findExportByName('libnetwork.dylib', 'nw_connection_create');
+const libnetwork = Process.getModuleByName('libnetwork.dylib');
+const nw_connection_create = libnetwork.getExportByName('nw_connection_create');
 
 // This is the method to make a new endpoint to connect to:
 // https://developer.apple.com/documentation/network/2976720-nw_endpoint_create_host (iOS 12+)
 const nw_endpoint_create_host = new NativeFunction(
-    Module.findExportByName('libnetwork.dylib', 'nw_endpoint_create_host'),
+    libnetwork.findExportByName('nw_endpoint_create_host'),
     'pointer', ['pointer', 'pointer']
 );
 

--- a/native-connect-hook.js
+++ b/native-connect-hook.js
@@ -21,11 +21,15 @@ const PROXY_HOST_IPv4_BYTES = PROXY_HOST.split('.').map(part => parseInt(part, 1
 const IPv6_MAPPING_PREFIX_BYTES = [0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xff];
 const PROXY_HOST_IPv6_BYTES = IPv6_MAPPING_PREFIX_BYTES.concat(PROXY_HOST_IPv4_BYTES);
 
-const connectFn = (
-    Module.findExportByName('libc.so', 'connect') ?? // Android
-    Module.findExportByName('libc.so.6', 'connect') ?? // Linux
-    Module.findExportByName('libsystem_kernel.dylib', 'connect') // iOS
-);
+let connectFn = null;
+try {
+    connectFn =
+        Process.getModuleByName('libc.so').findExportByName('connect') ?? //Android
+        Process.getModuleByName('libc.so.6').findExportByName('connect') ?? // Linux
+        Process.getModuleByName('libsystem_kernel.dylib').findExportByName('connect'); //IOS
+} catch (e) {
+    console.error("Failed to find 'connect' export:", e);
+}
 
 if (!connectFn) { // Should always be set, but just in case
     console.warn('Could not find libc connect() function to hook raw traffic');

--- a/native-connect-hook.js
+++ b/native-connect-hook.js
@@ -24,9 +24,9 @@ const PROXY_HOST_IPv6_BYTES = IPv6_MAPPING_PREFIX_BYTES.concat(PROXY_HOST_IPv4_B
 let connectFn = null;
 try {
     connectFn =
-        Process.getModuleByName('libc.so').findExportByName('connect') ?? //Android
-        Process.getModuleByName('libc.so.6').findExportByName('connect') ?? // Linux
-        Process.getModuleByName('libsystem_kernel.dylib').findExportByName('connect'); //IOS
+        Process.findModuleByName('libc.so')?.findExportByName('connect') ?? // Android
+        Process.findModuleByName('libc.so.6')?.findExportByName('connect') ?? // Linux
+        Process.findModuleByName('libsystem_kernel.dylib')?.findExportByName('connect'); // iOS
 } catch (e) {
     console.error("Failed to find 'connect' export:", e);
 }


### PR DESCRIPTION
Replaced deprecated
```js
const connectFn = (
    Module.findExportByName('libc.so', 'connect') ?? // Android
    Module.findExportByName('libc.so.6', 'connect') ?? // Linux
    Module.findExportByName('libsystem_kernel.dylib', 'connect') // iOS
);

```
with
```js
let connectFn = null;
try {
    connectFn =
        Process.getModuleByName('libc.so').findExportByName('connect') ?? //Android
        Process.getModuleByName('libc.so.6').findExportByName('connect') ?? // Linux
        Process.getModuleByName('libsystem_kernel.dylib').findExportByName('connect'); //IOS
} catch (e) {
    console.error("Failed to find 'connect' export:", e);
}
```
 as per Frida v17 changes.
Tested with both Frida v16 and v17, works as expected.