### PR TITLE
fix: Correct README script path for android-disable-root-detection.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The scripts can automatically handle:
         -l ./android/android-system-certificate-injection.js \
         -l ./android/android-certificate-unpinning.js \
         -l ./android/android-certificate-unpinning-fallback.js \
-        -l ./android/disable-root-detection.js \
+        -l ./android/android-disable-root-detection.js \
         -f $PACKAGE_ID
     ```
 7. Explore, examine & modify all the traffic you're interested in! If you have any problems, please [open an issue](https://github.com/httptoolkit/frida-interception-and-unpinning/issues/new) and help make these scripts even better.


### PR DESCRIPTION
### Summary
Fixed a typo in the Frida command example in the README where the script `android-disable-root-detection.js` was incorrectly referenced as `disable-root-detection.js`.

### Context
The actual script is located at `./android/android-disable-root-detection.js`, consistent with other Android scripts. This change prevents confusion or runtime errors when users copy the command directly.

### Changes
- Corrected filename in README

No code changes involved—this is purely a documentation fix.