### PR TITLE
fix(native-connect-hook): adjust scope of `systemModule` declaration

### DIFF
--- a/native-connect-hook.js
+++ b/native-connect-hook.js
@@ -29,9 +29,9 @@
         ? 4
         : 2048; // Linux/Android
 
-    let fcntl, send, recv;
+    let systemModule, fcntl, send, recv;
     try {
-        const systemModule = Process.findModuleByName('libc.so') ?? // Android
+        systemModule = Process.findModuleByName('libc.so') ?? // Android
                              Process.findModuleByName('libc.so.6') ?? // Linux
                              Process.findModuleByName('libsystem_kernel.dylib'); // iOS
 


### PR DESCRIPTION
### Summary
This pull request fixes a variable scope issue with `systemModule` in the native connect hook logic. The declaration of `systemModule` is moved outside of the `try` block so it is available to the entire function.
### Details
Previously, `systemModule` was declared within the `try` block and would be undefined outside of it. This could cause a runtime error in the `Interceptor.attach(...)` call, where is used, since `systemModule` would not be available if declared only inside the `try`. By moving the declaration to the outer scope, the variable remains accessible even after the `try` block, allowing the rest of the function to safely reference `systemModule`. `systemModule.getExportByName('connect')`
### Motivation
Ensuring `systemModule` is properly scoped prevents runtime errors when setting up native function hooks, and makes the code easier to understand and maintain.


_-- Pull Request Generated with AI --_