### PR TITLE
Add overload for `checkServerTrusted` method in *Appmattus* hooks

### DIFF
--- a/android/android-certificate-unpinning.js
+++ b/android/android-certificate-unpinning.js
@@ -449,7 +449,9 @@ const PINNING_FIXES = {
         {
             methodName: 'checkServerTrusted',
             overload: ['[Ljava.security.cert.X509Certificate;', 'java.lang.String'],
-            replacement: CHECK_OUR_TRUST_MANAGER_ONLY,
+            replacement: CHECK_OUR_TRUST_MANAGER_ONLY
+        },
+        {
             methodName: 'checkServerTrusted',
             overload: ['[Ljava.security.cert.X509Certificate;', 'java.lang.String', 'java.lang.String'],
             replacement: () => {


### PR DESCRIPTION
This overload was ignored beforehand because of an ill-formed data structure.